### PR TITLE
remove comma from icon name causing warning

### DIFF
--- a/src/components/Icon/icons/index.ts
+++ b/src/components/Icon/icons/index.ts
@@ -165,7 +165,7 @@ export default [
   'Swap',
   'TakeSelfie',
   'Tea',
-  'Telecommunications,',
+  'Telecommunications',
   'Terms',
   'ThumbsUp',
   'Time',


### PR DESCRIPTION
- removed comma in a icon's string