### PR TITLE
[feat(OK-3472)]: Photon v2 input component

### DIFF
--- a/src/components v2/Input/Input.stories.js
+++ b/src/components v2/Input/Input.stories.js
@@ -1,0 +1,32 @@
+import P2Input from './Input.vue';
+import '../../assets/scss/main.scss';
+
+const bool = { options: [true, false] };
+
+export default {
+  title: 'v2/Forms/Input',
+  component: P2Input,
+  // Set the order of the props
+  argTypes: {
+    hideErrors: bool,
+    errors: {
+      control: 'array',
+      defaultValue: ['Error 1', 'Error 2'],
+    },
+  },
+  // Set the initial values of the props
+  args: {},
+};
+
+const BasicTemplate = (args, { argTypes }) => ({
+  components: { P2Input },
+  props: Object.keys(argTypes),
+  template: `
+    <div class="ph-flex">
+      <p2-input v-bind="$props" />
+    </div>
+  `,
+});
+
+export const Basic = BasicTemplate.bind({});
+Basic.argTypes = {};

--- a/src/components v2/Input/Input.vue
+++ b/src/components v2/Input/Input.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="photon-input">
+    <slot />
+    <div
+      class="photon-input-error"
+      :class="{
+        hidden: !(errors.length && !hideErrors),
+      }"
+    >
+      <p-icon
+        class="icon"
+        :class="{
+          hidden: !(errors.length && !hideErrors),
+        }"
+        name="Error"
+        type="sm"
+      />
+      <p-text sm class="photon-input-error-text">
+        {{ errorsMessages }}
+      </p-text>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import PIcon from '../../components/Icon';
+import { PText } from '../../components/Typography';
+
+export default Vue.extend({
+  name: 'P2Input',
+  components: {
+    PIcon,
+    PText,
+  },
+  props: {
+    hideErrors: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
+    errors: {
+      type: Array as PropType<string[]>,
+      default: (): [] => [],
+    },
+  },
+  computed: {
+    errorsMessages(): string {
+      return this.errors.join(', ');
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+@import './src/assets/scss/_themehelpers.scss';
+
+@function getInputErrorProperty($property, $fallback: '') {
+  @return getThemeProperty('input-error', $property, 'base', '', $fallback);
+}
+
+.photon-input {
+  .photon-input-error {
+    display: flex;
+    align-items: center;
+    opacity: 1;
+    font-size: getInputErrorProperty('font-size', 0.75rem);
+    line-height: getInputErrorProperty('line-height', 1.5rem);
+    min-height: getInputErrorProperty('min-height', 1.5rem);
+    padding: getInputErrorProperty('padding', 0.25rem);
+    color: getInputErrorProperty('color', red);
+
+    &.hidden {
+      opacity: 0;
+    }
+
+    .icon {
+      margin-right: 4px;
+      opacity: 1;
+      &.hidden {
+        opacity: 0;
+      }
+    }
+
+    .photon-input-error-text {
+      min-height: getInputErrorProperty('min-height', 1.5rem);
+    }
+  }
+}
+</style>

--- a/src/components v2/Input/index.ts
+++ b/src/components v2/Input/index.ts
@@ -1,0 +1,3 @@
+import PInput from './Input.vue';
+
+export default PInput;

--- a/src/components v2/index.ts
+++ b/src/components v2/index.ts
@@ -1,5 +1,6 @@
 import { Component } from 'vue';
 import P2Button from './Button';
+import P2Input from './Input';
 
 export interface PhotonComponents {
   [key: string]: Component;
@@ -7,6 +8,7 @@ export interface PhotonComponents {
 
 const components: PhotonComponents = {
   P2Button,
+  P2Input,
 };
 
 export type PhotonComponentKeys = keyof PhotonComponents;

--- a/src/components/InputBasicSelect/InputBasicSelect.spec.js
+++ b/src/components/InputBasicSelect/InputBasicSelect.spec.js
@@ -1,4 +1,4 @@
-import InputBasicSelect from '@/components/InputSelect/InputBasicSelect.vue';
+import InputBasicSelect from '@/components/InputBasicSelect/InputBasicSelect.vue';
 import { createWrapper } from '@/utils/unitTest';
 
 describe('InputSelect.vue', () => {

--- a/src/theme/styles/inputError.theme.json
+++ b/src/theme/styles/inputError.theme.json
@@ -1,0 +1,11 @@
+{
+  "input-error": {
+    "base": {
+      "font-size": "0.875rem",
+      "line-height": "1.5",
+      "min-height": "1.5em",
+      "padding": "0.25rem",
+      "color": "{{colors.danger.500}}"
+    }
+  }
+}


### PR DESCRIPTION
Ticket: https://verteva.atlassian.net/browse/OK-3472

Adding the basic input component wrapper for photon v2. 

Note: The basic input component is a wrapper for other inputs. It only styles the errors.
