### PR TITLE
fix: use user token for release-pr so that actions run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Release
         env:
+          GH_TOKEN_RELEASE: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}


### PR DESCRIPTION
# Description
Shifted to using an access token for the release-pr. This access token does not have admin access. It is only used to create a pull request that will then run the needed GitHub actions (jest-test) so that admin pushes are not required. 

The generated `GITHUB_TOKEN` does not trigger additional workflows to protect itself from infinite loops.

## Type of change
<!-- Delete irrelevant checklist items -->
- [x] Bug fix (

## PR checklist
- [x] I have run the test suite locally and fixed any issues that were caught
- [x] I have written unit tests for new functionality
- [x] I have added changelog notes for this pr
