### PR TITLE
fix: can hide form control error. added input checkbox slot

### DIFF
--- a/scripts/gets3files.sh
+++ b/scripts/gets3files.sh
@@ -4,7 +4,7 @@
 #aws s3api get-object --bucket figma-themes --key 'figmaThemes/version/latest/nano.json' public/figmaThemes/nano.json
 #aws s3api get-object --bucket figma-themes --key 'figmaThemes/version/latest/amp.json' public/figmaThemes/amp.json
 
-aws s3api get-object --bucket figma-themes --key 'cx-themes/version/latest/themes.json' public/cxThemes/themes.json
-aws s3api get-object --bucket figma-themes --key 'cx-themes/version/latest/Nano.json' public/cxThemes/Nano.json
-aws s3api get-object --bucket figma-themes --key 'cx-themes/version/latest/suncorp.json' public/cxThemes/suncorp.json
-aws s3api get-object --bucket figma-themes --key 'cx-themes/version/latest/amp.json' public/cxThemes/amp.json
+aws s3api get-object --bucket figma-themes --key 'cx-themes/version/latest/styles/themes.json' public/cxThemes/themes.json
+aws s3api get-object --bucket figma-themes --key 'cx-themes/version/latest/styles/Nano.json' public/cxThemes/Nano.json
+aws s3api get-object --bucket figma-themes --key 'cx-themes/version/latest/styles/suncorp.json' public/cxThemes/suncorp.json
+aws s3api get-object --bucket figma-themes --key 'cx-themes/version/latest/styles/amp.json' public/cxThemes/amp.json

--- a/src/components v2/Molecules/Forms/FormControl/FormControl.vue
+++ b/src/components v2/Molecules/Forms/FormControl/FormControl.vue
@@ -21,6 +21,7 @@
       <slot :size="size" />
     </div>
     <P2ErrorMessage
+      v-if="!hideError"
       v-bind="{
         error,
         size,
@@ -76,6 +77,10 @@ export default Vue.extend({
       default: '',
     },
     // Global props
+    hideError: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
     size: {
       type: String as PropType<FORM_CONTROL_SIZE_TYPE>,
       default: FORM_CONTROL_SIZE.MEDIUM,

--- a/src/components v2/Molecules/Forms/InputCheckbox/InputCheckbox.vue
+++ b/src/components v2/Molecules/Forms/InputCheckbox/InputCheckbox.vue
@@ -9,6 +9,7 @@
       error,
       size,
       disabled,
+      hideError,
     }"
   >
     <P2Checkbox
@@ -20,7 +21,9 @@
         disabled,
       }"
       @input="$emit('input', $event)"
-    />
+    >
+      <slot />
+    </P2Checkbox>
   </P2FormControl>
 </template>
 
@@ -75,6 +78,10 @@ export default Vue.extend({
     error: {
       type: String as PropType<string>,
       default: '',
+    },
+    hideError: {
+      type: Boolean as PropType<boolean>,
+      default: false,
     },
     // Checkbox Props
     name: {

--- a/src/components v2/Molecules/Forms/InputCheckboxGroup/InputCheckboxGroup.vue
+++ b/src/components v2/Molecules/Forms/InputCheckboxGroup/InputCheckboxGroup.vue
@@ -9,6 +9,7 @@
       error,
       size,
       disabled,
+      hideError,
     }"
   >
     <P2CheckboxGroup
@@ -75,6 +76,10 @@ export default Vue.extend({
     error: {
       type: String as PropType<string>,
       default: '',
+    },
+    hideError: {
+      type: Boolean as PropType<boolean>,
+      default: false,
     },
 
     // CheckboxGroup props


### PR DESCRIPTION
# Description
fix:
- Small update to script. Now follows the new key naming convention
- Added `hideError` prop to the form control and everything using the form control. If the field has no error we can remove it.
- Added slot into the `InputCheckbox` component.

## Type of change
<!-- Delete irrelevant checklist items -->
- [x] Bug fix (non-breaking change which fixes an issue)

## PR checklist
- [x] I have run the test suite locally and fixed any issues that were caught
- [x] I have written unit tests for new functionality
