### PR TITLE
chore: removed stories from sonarcloud scans

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,6 +15,7 @@ sonar.test.inclusions=**/*.spec.ts, **/*.spec.js, **/test/**
 sonar.exclusions = \
   ${env.SONAR_ADDITIONAL_EXCLUSIONS},\
     **/?(*.)+(spec|test).+(js|ts),\
+    **/*.stories.js,\
     **/test/**,\
     **/__snapshots__/**,\
     src/assets/**


### PR DESCRIPTION
# Description
excluding `stories.js` files from our sonar scan. These files do not need quality standards as they are helpers for our display.

## Type of change
<!-- Delete irrelevant checklist items -->
- [x] Bug fix (non-breaking change which fixes an issue)

