### PR TITLE
d/cx 139 bug select autocomplete value get set

### DIFF
--- a/src/components v2/Atoms/Forms/InputSelect/InputSelect.vue
+++ b/src/components v2/Atoms/Forms/InputSelect/InputSelect.vue
@@ -77,8 +77,8 @@ export const props = {
     default: true,
   },
   initInput: {
-    type: String as PropType<string>,
-    default: '',
+    type: [Number, String, Object] as PropType<string | number>,
+    default: null,
   },
   selectedBy: {
     type: String as PropType<string>,

--- a/src/components v2/Atoms/Forms/InputSelect/InputSelect.vue
+++ b/src/components v2/Atoms/Forms/InputSelect/InputSelect.vue
@@ -11,6 +11,7 @@
       :init-input="value"
       :value="value"
       :disabled="disabled"
+      :selected-by="selectedBy"
       hide-clear-btn
       :reduce-prefix-spacing="reducePrefixSpacing"
       :simple="simple"
@@ -78,6 +79,10 @@ export const props = {
   initInput: {
     type: String as PropType<string>,
     default: '',
+  },
+  selectedBy: {
+    type: String as PropType<string>,
+    default: 'label',
   },
 };
 

--- a/src/components v2/Molecules/Forms/InputSelect/InputSelect.vue
+++ b/src/components v2/Molecules/Forms/InputSelect/InputSelect.vue
@@ -27,6 +27,7 @@
         reducePrefixSpacing,
         simple,
         initInput,
+        selectedBy,
       }"
       @input="$emit('input', $event)"
     />
@@ -56,6 +57,7 @@ const {
   reducePrefixSpacing,
   simple,
   initInput,
+  selectedBy,
 } = InputSelectProps;
 const { size, disabled } = formProps;
 const {
@@ -93,6 +95,7 @@ export const props = {
   reducePrefixSpacing,
   simple,
   initInput,
+  selectedBy,
 };
 
 export default Vue.extend({


### PR DESCRIPTION
# Description
Fix to allow InputSelect to accept non-string values (eg: Number) to resolve a bug with this component when used to select loan term or io loan term. 
https://verteva.atlassian.net/browse/CX-139

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## PR checklist
- [x] I have run the test suite locally and fixed any issues that were caught

