### PR TITLE
fix: update word break for dialogs with long words

### DIFF
--- a/src/components v2/Atoms/Components/Headline/Headline.vue
+++ b/src/components v2/Atoms/Components/Headline/Headline.vue
@@ -26,6 +26,7 @@ export default Vue.extend({
   font-size: var(--headline-default-font-size);
   line-height: var(--headline-default-line-height);
   letter-spacing: var(--headline-default-letter-spacing);
+  word-break: break-word;
 
   &.sm {
     font-size: var(--headline-sm-font-size);


### PR DESCRIPTION
# Description
Dialogs with long single words (such as file names) did not break the word causing it to be unreadable.

## Type of change
<!-- Delete irrelevant checklist items -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR checklist
- [ ] I have run the test suite locally and fixed any issues that were caught
- [ ] I have written unit tests for new functionality
