### PR TITLE
refactor(InputPhone): remove deprecated event names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanonpm/photon",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nanonpm/photon",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "private": false,
   "repository": {
     "type": "git",

--- a/src/components v2/Atoms/Forms/InputPhone/InputPhone.vue
+++ b/src/components v2/Atoms/Forms/InputPhone/InputPhone.vue
@@ -12,12 +12,13 @@
       }"
       :disabled="disabled"
       no-search
+      no-example
       no-validation
       show-code-on-list
       @input="$emit('input', $event)"
       @update="onUpdate"
-      @phone-number-focused="onFocus"
-      @phone-number-blur="onBlur"
+      @focus="onFocus"
+      @blur="onBlur"
     />
   </div>
 </template>


### PR DESCRIPTION
# Description
https://verteva.atlassian.net/browse/CRE-1834
- refactored the phone input component to correctly use focus and blur event handlers
- although there's no documentation available for the maz library for the version we use @focus and @blur 
- I've bumped the version up for photon as well

